### PR TITLE
Return NaN if reading failed & Added readUVABI()

### DIFF
--- a/Adafruit_VEML6075.cpp
+++ b/Adafruit_VEML6075.cpp
@@ -316,3 +316,19 @@ float Adafruit_VEML6075::readUVI() {
   takeReading();
   return ((_uva_calc * _uva_resp) + (_uvb_calc * _uvb_resp)) / 2;
 }
+
+/**************************************************************************/
+/*!
+    @brief  read the calibrated UVA & UVB band reading and calculate the
+   approximate UV Index reading
+        @param a pointer to store UVA reading or NAN if reading failed
+        @param b pointer to store UVB reading or NAN if reading failed
+        @param i pointer to store UVI reading or NAN if reading failed
+*/
+/**************************************************************************/
+void Adafruit_VEML6075::readUVABI(float *a, float *b, float *i) {
+  takeReading();
+  *a = _uva_calc;
+  *b = _uvb_calc;
+  *i = ((_uva_calc * _uva_resp) + (_uvb_calc * _uvb_resp)) / 2;
+}

--- a/Adafruit_VEML6075.cpp
+++ b/Adafruit_VEML6075.cpp
@@ -265,6 +265,14 @@ void Adafruit_VEML6075::takeReading(void) {
   float uvcomp1 = UVCOMP1_Register.read();
   float uvcomp2 = UVCOMP2_Register.read();
 
+  if (uva == 0xFFFFFFFF || uvb == 0xFFFFFFFF || uvcomp1 == 0xFFFFFFFF ||
+      uvcomp2 == 0xFFFFFFFF) {
+    uva = NAN;
+    uvb = NAN;
+    uvcomp1 = NAN;
+    uvcomp2 = NAN;
+  }
+
   /*
   Serial.print("UVA: "); Serial.print(uva);
   Serial.print(" UVB: "); Serial.println(uvb);
@@ -279,7 +287,7 @@ void Adafruit_VEML6075::takeReading(void) {
 /**************************************************************************/
 /*!
     @brief  read the calibrated UVA band reading
-    @return the UVA reading in unitless counts
+    @return the UVA reading in unitless counts or NAN if reading failed
 */
 /*************************************************************************/
 float Adafruit_VEML6075::readUVA(void) {
@@ -290,7 +298,7 @@ float Adafruit_VEML6075::readUVA(void) {
 /**************************************************************************/
 /*!
     @brief  read the calibrated UVB band reading
-    @return the UVB reading in unitless counts
+    @return the UVB reading in unitless counts or NAN if reading failed
 */
 /*************************************************************************/
 float Adafruit_VEML6075::readUVB(void) {
@@ -301,7 +309,7 @@ float Adafruit_VEML6075::readUVB(void) {
 /**************************************************************************/
 /*!
     @brief  Read and calculate the approximate UV Index reading
-    @return the UV Index as a floating point
+    @return the UV Index as a floating point or NAN if reading failed
 */
 /**************************************************************************/
 float Adafruit_VEML6075::readUVI() {

--- a/Adafruit_VEML6075.h
+++ b/Adafruit_VEML6075.h
@@ -97,6 +97,7 @@ public:
   float readUVA(void);
   float readUVB(void);
   float readUVI(void);
+  void readUVABI(float *a, float *b, float *i);
 
   Adafruit_I2CRegister *Config_Register; ///< Chip config register
 


### PR DESCRIPTION
- Functions ```readUVA()```, ```readUVB()``` and ```readUVI()``` return NaN instead of huge negative number when sensor is disconnected or reading fails because of any other reason.
- Implemented ```void readUVABI(float *a, float *b, float *i);``` function regarding issue #6.

Code on which I've tested changes:
```C++
#include <Wire.h>
#include "Adafruit_VEML6075.h"

Adafruit_VEML6075 uv = Adafruit_VEML6075();

void setup() {
  Serial.begin(115200);
  Serial.println("VEML6075 Full Test");
  if (! uv.begin()) {
    Serial.println("Failed to communicate with VEML6075 sensor, check wiring?");
  }
  Serial.println("Found VEML6075 sensor");

  uv.setIntegrationTime(VEML6075_100MS);
  uv.setHighDynamic(true);
  uv.setForcedMode(false);
  uv.setCoefficients(2.22, 1.33, 2.95, 1.74, 0.001461, 0.002591);
}


void loop() {
  float uva;
  float uvb;
  float uvi;

  uv.readUVABI(&uva, &uvb, &uvi);
  Serial.print("Raw UVA reading:  "); Serial.println(uva);
  Serial.print("Raw UVB reading:  "); Serial.println(uvb);
  Serial.print("UV Index reading: "); Serial.println(uvi);

  delay(1000);
}
```

Output with sensor connected (inside room):
```
Raw UVA reading:  6.78
Raw UVB reading:  8.05
UV Index reading: 0.02
```

Output with sensor disconnected:
```
Raw UVA reading:  nan
Raw UVB reading:  nan
UV Index reading: nan
```